### PR TITLE
Add Display impls for string newtypes and Color

### DIFF
--- a/calendar-types/src/css.rs
+++ b/calendar-types/src/css.rs
@@ -3,9 +3,9 @@
 use strum::EnumString;
 
 /// CSS3 colors as defined by [the W3C recommendation.](https://www.w3.org/TR/css-color-3/)
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, EnumString)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, EnumString, strum::Display)]
 #[repr(u8)]
-#[strum(ascii_case_insensitive)]
+#[strum(ascii_case_insensitive, serialize_all = "lowercase")]
 pub enum Css3Color {
     AliceBlue,
     AntiqueWhite,

--- a/calendar-types/src/string.rs
+++ b/calendar-types/src/string.rs
@@ -25,6 +25,12 @@ pub enum InvalidUidError {
 #[repr(transparent)]
 pub struct Uid(str);
 
+impl std::fmt::Display for Uid {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 impl Uid {
     fn str_is_uid(s: &str) -> Result<(), InvalidUidError> {
         if s.is_empty() {
@@ -62,6 +68,12 @@ pub enum InvalidUriError {
 #[dizzy(derive_owned(Debug, IntoBoxed))]
 #[repr(transparent)]
 pub struct Uri(str);
+
+impl std::fmt::Display for Uri {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
 
 impl Uri {
     fn str_is_uri(s: &str) -> Result<(), InvalidUriError> {

--- a/jscalendar/src/model/set.rs
+++ b/jscalendar/src/model/set.rs
@@ -168,6 +168,15 @@ pub enum Color {
     Rgb(Rgb),
 }
 
+impl std::fmt::Display for Color {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Color::Css(css) => write!(f, "{css}"),
+            Color::Rgb(rgb) => write!(f, "#{:02x}{:02x}{:02x}", rgb.red, rgb.green, rgb.blue),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 #[error("not a known CSS3 color name or #RRGGBB hex string: {0:?}")]
 pub struct InvalidColorError(pub Box<str>);

--- a/jscalendar/src/model/string.rs
+++ b/jscalendar/src/model/string.rs
@@ -153,6 +153,12 @@ impl std::fmt::Debug for Id {
     }
 }
 
+impl std::fmt::Display for Id {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 impl Id {
     const fn check_slice(value: &[IdChar]) -> Result<(), InvalidIdError> {
         match value.len() {
@@ -395,6 +401,12 @@ impl<V: DestructibleJsonValue> TryFromJson<V> for Box<CustomTimeZoneId> {
     }
 }
 
+impl std::fmt::Display for CustomTimeZoneId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
 impl CustomTimeZoneId {
     fn str_is_custom_time_zone_id(s: &str) -> Result<(), InvalidCustomTimeZoneIdError> {
         let body = s.strip_prefix('/').ok_or(if s.is_empty() {
@@ -442,6 +454,12 @@ pub enum InvalidImplicitJsonPointerError {
 #[dizzy(derive_owned(Debug, IntoBoxed))]
 #[repr(transparent)]
 pub struct ImplicitJsonPointer(str);
+
+impl std::fmt::Display for ImplicitJsonPointer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
 
 impl ImplicitJsonPointer {
     fn str_is_implicit_json_pointer(s: &str) -> Result<(), InvalidImplicitJsonPointerError> {
@@ -520,6 +538,12 @@ pub enum InvalidVendorStrError {
 #[dizzy(derive_owned(Debug, IntoBoxed))]
 #[repr(transparent)]
 pub struct VendorStr(str);
+
+impl std::fmt::Display for VendorStr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
 
 impl VendorStr {
     const fn is_vendor_str(s: &str) -> Result<(), InvalidVendorStrError> {
@@ -610,6 +634,12 @@ impl<V: DestructibleJsonValue> TryFromJson<V> for Box<CalAddress> {
     }
 }
 
+impl std::fmt::Display for CalAddress {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 impl CalAddress {
     fn str_is_cal_address(s: &str) -> Result<(), InvalidCalAddressError> {
         if s.is_empty() {
@@ -668,6 +698,12 @@ impl<V: DestructibleJsonValue> TryFromJson<V> for Box<EmailAddr> {
                 error,
             })
             .map_err(TypeErrorOr::Other)
+    }
+}
+
+impl std::fmt::Display for EmailAddr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
     }
 }
 
@@ -757,6 +793,12 @@ impl<V: DestructibleJsonValue> TryFromJson<V> for Box<GeoUri> {
     }
 }
 
+impl std::fmt::Display for GeoUri {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 impl GeoUri {
     fn str_is_geo_uri(s: &str) -> Result<(), InvalidGeoUriError> {
         if s.is_empty() {
@@ -828,6 +870,12 @@ impl<V: DestructibleJsonValue> TryFromJson<V> for Box<ContentId> {
     }
 }
 
+impl std::fmt::Display for ContentId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 impl ContentId {
     fn str_is_content_id(s: &str) -> Result<(), InvalidContentIdError> {
         if s.is_empty() {
@@ -874,6 +922,12 @@ impl<V: DestructibleJsonValue> TryFromJson<V> for Box<MediaType> {
                 error,
             })
             .map_err(TypeErrorOr::Other)
+    }
+}
+
+impl std::fmt::Display for MediaType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
     }
 }
 
@@ -933,6 +987,12 @@ impl MediaType {
 #[dizzy(derive(Debug, CloneBoxed, IntoBoxed))]
 #[repr(transparent)]
 pub struct AlphaNumeric(str);
+
+impl std::fmt::Display for AlphaNumeric {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
 
 impl AlphaNumeric {
     pub fn str_is_alphanumeric(s: &str) -> Result<(), InvalidAlphaNumericError> {


### PR DESCRIPTION
## Summary
- Adds `Display` implementations for 13 string newtypes across `calendar-types` and `jscalendar`, plus `Color`
- `Css3Color` gains `strum::Display` with `serialize_all = "lowercase"` for canonical lowercase output
- `Color` formats as CSS name (lowercase) or `#rrggbb` hex

Closes #5

## Test plan
- [x] `cargo test --all-features` — all 205 tests pass
- [x] `cargo clippy --all-features` — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)