### PR TITLE
jscalendar: add #[non_exhaustive] to public enums in object.rs

### DIFF
--- a/jscalendar/src/model/object.rs
+++ b/jscalendar/src/model/object.rs
@@ -70,6 +70,7 @@ pub struct Group<V: JsonValue> {
 }
 
 /// A [`Task`] or an [`Event`].
+#[non_exhaustive]
 pub enum TaskOrEvent<V: JsonValue> {
     Task(Task<V>),
     Event(Event<V>),
@@ -458,6 +459,7 @@ pub struct Alert<V: JsonValue> {
 
 /// The trigger of an [`Alert`].
 #[derive(PartialEq)]
+#[non_exhaustive]
 pub enum Trigger<V: JsonValue> {
     Offset(OffsetTrigger<V>),
     Absolute(AbsoluteTrigger<V>),
@@ -601,6 +603,7 @@ impl<V: DestructibleJsonValue> TryFromJson<V> for PatchObject<V> {
 // ============================================================================
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[non_exhaustive]
 pub enum ObjectFromJsonError {
     #[error("missing required field: {0}")]
     MissingField(&'static str),
@@ -786,6 +789,7 @@ fn parse_request_status(s: &str) -> Option<RequestStatus> {
 // ============================================================================
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[non_exhaustive]
 pub enum RRuleFromJsonError {
     #[error("missing required field: {0}")]
     MissingField(&'static str),
@@ -1094,6 +1098,7 @@ fn parse_date_or_datetime(s: &str) -> Option<DateTimeOrDate<crate::model::time::
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[non_exhaustive]
 pub enum ByRuleParseError {
     #[error("invalid value in by-rule array")]
     InvalidValue,


### PR DESCRIPTION
## Summary
- Marks `TaskOrEvent`, `Trigger`, `ObjectFromJsonError`, `RRuleFromJsonError`, and `ByRuleParseError` as `#[non_exhaustive]`
- Prevents downstream exhaustive matching, preserving semver compatibility for future variant additions
- All enums in `set.rs` were already non-exhaustive; this brings `object.rs` in line

Closes #4

## Test plan
- [x] `cargo test --all-features` — all 205 tests pass
- [x] `cargo clippy --all-features` — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)