### PR TITLE
Add doc comments to undocumented public items

### DIFF
--- a/jscalendar/src/json.rs
+++ b/jscalendar/src/json.rs
@@ -22,6 +22,7 @@ use crate::parser::{
     UtcDateTimeParseError, duration, local_date_time, parse_full, signed_duration, utc_date_time,
 };
 
+/// Fallible conversion from a JSON value into a Rust type.
 pub trait TryFromJson<V>
 where
     Self: Sized,
@@ -179,6 +180,7 @@ where
     }
 }
 
+/// Error returned when parsing a `HashSet` from a JSON object.
 #[derive(Debug, Clone, Copy, PartialEq, Error)]
 pub enum HashSetTryFromJsonError<E> {
     #[error("encountered `false` as a value in a set")]
@@ -223,6 +225,7 @@ where
     }
 }
 
+/// Fallible conversion from a Rust type into a JSON value.
 pub trait TryIntoJson<V>
 where
     V: ConstructibleJsonValue,
@@ -232,6 +235,7 @@ where
     fn try_into_json(self) -> Result<V, Self::Error>;
 }
 
+/// Infallible conversion from a Rust type into a JSON value.
 pub trait IntoJson<V>
 where
     V: ConstructibleJsonValue,
@@ -247,6 +251,7 @@ impl<T: IntoJson<V>, V: ConstructibleJsonValue> TryIntoJson<V> for T {
     }
 }
 
+/// Conversion of a field-level error into a [`DocumentError`] with a JSON path.
 pub trait IntoDocumentError: Sized {
     type Residual;
 
@@ -307,6 +312,7 @@ impl<E: IntoDocumentError> IntoDocumentError for DocumentError<E> {
     }
 }
 
+/// Lifts a [`TypeError`] into the [`TypeErrorOr`] wrapper so that nested errors compose uniformly.
 pub trait LiftTypeError {
     type Residual;
 
@@ -348,6 +354,7 @@ impl<E> LiftTypeError for TypeErrorOr<E> {
     }
 }
 
+/// An error annotated with the JSON path at which it occurred.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DocumentError<E> {
     pub(crate) path: VecDeque<PathSegment<Box<str>>>,
@@ -396,10 +403,14 @@ impl<E: std::fmt::Display> std::fmt::Display for DocumentError<E> {
 
 impl<E: std::fmt::Display + std::fmt::Debug> std::error::Error for DocumentError<E> {}
 
+/// A single segment in a JSON path.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PathSegment<S> {
+    /// An array index.
     Index(usize),
+    /// A statically-known object key.
     Static(&'static str),
+    /// A dynamically-owned object key.
     String(S),
 }
 
@@ -617,6 +628,7 @@ impl std::fmt::Display for ValueType {
     }
 }
 
+/// Either a JSON type mismatch or a domain-specific error `E`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
 #[error(transparent)]
 pub enum TypeErrorOr<E> {
@@ -624,6 +636,7 @@ pub enum TypeErrorOr<E> {
     Other(E),
 }
 
+/// The JSON value had the wrong type (e.g. expected a string but received an object).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Error)]
 #[error("expected a value of type {expected} but received type {received} instead")]
 pub struct TypeError {
@@ -631,6 +644,7 @@ pub struct TypeError {
     pub received: ValueType,
 }
 
+/// Error returned when a JSON number cannot be converted to [`Int`].
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Error)]
 pub enum IntoIntError {
     #[error("expected an integer but received {0}")]
@@ -641,6 +655,7 @@ pub enum IntoIntError {
     OutsideRangeUnsigned(u64),
 }
 
+/// Error returned when a JSON number cannot be converted to [`UnsignedInt`].
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Error)]
 pub enum IntoUnsignedIntError {
     #[error("expected an integer but received {0}")]

--- a/jscalendar/src/model/object.rs
+++ b/jscalendar/src/model/object.rs
@@ -554,6 +554,7 @@ impl<V> PatchObject<V> {
     }
 }
 
+/// A [`PatchObject`] key was not a valid implicit JSON pointer.
 #[derive(Debug, Clone, PartialEq, Error)]
 #[error("the key {key} is not an implicit JSON pointer")]
 pub struct InvalidPatchObjectError {
@@ -603,6 +604,7 @@ impl<V: DestructibleJsonValue> TryFromJson<V> for PatchObject<V> {
 // Error type and helpers for object parsing
 // ============================================================================
 
+/// Error returned when parsing a JSCalendar object from JSON.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 #[non_exhaustive]
 pub enum ObjectFromJsonError {
@@ -664,6 +666,7 @@ fn missing(field: &'static str) -> ObjErr {
 // UtcOffset TryFromJson
 // ============================================================================
 
+/// The string was not a valid `[+-]HH:MM[:SS]` UTC offset.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 #[error("invalid UTC offset string: {0:?}")]
 pub struct InvalidUtcOffsetError(pub Box<str>);
@@ -710,6 +713,7 @@ fn parse_utc_offset(s: &str) -> Option<UtcOffset> {
 // StatusCode TryFromJson
 // ============================================================================
 
+/// The string was not a valid `N.N[.N]` iCalendar status code.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 #[error("invalid status code string: {0:?}")]
 pub struct InvalidStatusCodeError(pub Box<str>);
@@ -755,6 +759,7 @@ fn parse_status_code(s: &str) -> Option<StatusCode> {
 // RequestStatus TryFromJson
 // ============================================================================
 
+/// The string was not a valid `code;description[;data]` request status.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 #[error("invalid request status string: {0:?}")]
 pub struct InvalidRequestStatusError(pub Box<str>);
@@ -789,6 +794,7 @@ fn parse_request_status(s: &str) -> Option<RequestStatus> {
 // RRule TryFromJson
 // ============================================================================
 
+/// Error returned when parsing a recurrence rule from JSON.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 #[non_exhaustive]
 pub enum RRuleFromJsonError {
@@ -1098,6 +1104,7 @@ fn parse_date_or_datetime(s: &str) -> Option<DateTimeOrDate<crate::model::time::
     None
 }
 
+/// Error returned when parsing a BYxxx recurrence rule component.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 #[non_exhaustive]
 pub enum ByRuleParseError {

--- a/jscalendar/src/model/set.rs
+++ b/jscalendar/src/model/set.rs
@@ -15,9 +15,13 @@ use crate::json::{ConstructibleJsonValue, DestructibleJsonValue, IntoJson, TryFr
 #[non_exhaustive]
 #[strum(ascii_case_insensitive, serialize_all = "lowercase")]
 pub enum RelationValue {
+    /// The first object in a series.
     First,
+    /// The next object in a series.
     Next,
+    /// A child of the referencing object.
     Child,
+    /// A parent of the referencing object.
     Parent,
 }
 
@@ -26,9 +30,13 @@ pub enum RelationValue {
 #[non_exhaustive]
 #[strum(ascii_case_insensitive, serialize_all = "lowercase")]
 pub enum DisplayPurpose {
+    /// A small icon or badge.
     Badge,
+    /// A banner or header graphic.
     Graphic,
+    /// The full-size image.
     FullSize,
+    /// A reduced-size preview.
     Thumbnail,
 }
 
@@ -37,7 +45,9 @@ pub enum DisplayPurpose {
 #[non_exhaustive]
 #[strum(ascii_case_insensitive, serialize_all = "lowercase")]
 pub enum FreeBusyStatus {
+    /// The user is available during this time.
     Free,
+    /// The user is not available during this time.
     Busy,
 }
 
@@ -46,8 +56,11 @@ pub enum FreeBusyStatus {
 #[non_exhaustive]
 #[strum(ascii_case_insensitive, serialize_all = "lowercase")]
 pub enum Privacy {
+    /// The object is fully visible.
     Public,
+    /// Only time and basic metadata are visible.
     Private,
+    /// The object is completely hidden.
     Secret,
 }
 
@@ -56,8 +69,11 @@ pub enum Privacy {
 #[non_exhaustive]
 #[strum(ascii_case_insensitive, serialize_all = "lowercase")]
 pub enum EventStatus {
+    /// The event is definite.
     Confirmed,
+    /// The event has been cancelled.
     Cancelled,
+    /// The event is tentative.
     Tentative,
 }
 
@@ -66,11 +82,15 @@ pub enum EventStatus {
 #[non_exhaustive]
 #[strum(ascii_case_insensitive, serialize_all = "lowercase")]
 pub enum TaskProgress {
+    /// The task has not been started.
     #[strum(serialize = "needs-action")]
     NeedsAction,
+    /// The task is in progress.
     #[strum(serialize = "in-process")]
     InProcess,
+    /// The task is finished.
     Completed,
+    /// The task has been cancelled.
     Cancelled,
 }
 
@@ -79,12 +99,19 @@ pub enum TaskProgress {
 #[non_exhaustive]
 #[strum(ascii_case_insensitive, serialize_all = "lowercase")]
 pub enum VirtualLocationFeature {
+    /// Audio conferencing.
     Audio,
+    /// Text chat.
     Chat,
+    /// A data feed (e.g. webinar).
     Feed,
+    /// Moderator access.
     Moderator,
+    /// Phone conferencing.
     Phone,
+    /// Screen sharing.
     Screen,
+    /// Video conferencing.
     Video,
 }
 
@@ -93,9 +120,13 @@ pub enum VirtualLocationFeature {
 #[non_exhaustive]
 #[strum(ascii_case_insensitive, serialize_all = "lowercase")]
 pub enum ParticipantKind {
+    /// A single person.
     Individual,
+    /// A group of people.
     Group,
+    /// A physical location.
     Location,
+    /// A schedulable resource (e.g. a projector).
     Resource,
 }
 
@@ -104,11 +135,17 @@ pub enum ParticipantKind {
 #[non_exhaustive]
 #[strum(ascii_case_insensitive, serialize_all = "lowercase")]
 pub enum ParticipantRole {
+    /// The calendar owner of this object.
     Owner,
+    /// A required attendee.
     Attendee,
+    /// An optional attendee.
     Optional,
+    /// A non-participant copied for information.
     Informational,
+    /// The chair of the event.
     Chair,
+    /// A contact for the event.
     Contact,
 }
 
@@ -117,11 +154,16 @@ pub enum ParticipantRole {
 #[non_exhaustive]
 #[strum(ascii_case_insensitive, serialize_all = "lowercase")]
 pub enum ParticipationStatus {
+    /// No response yet.
     #[strum(serialize = "needs-action")]
     NeedsAction,
+    /// The participant has accepted.
     Accepted,
+    /// The participant has declined.
     Declined,
+    /// The participant has tentatively accepted.
     Tentative,
+    /// The participant has delegated attendance.
     Delegated,
 }
 
@@ -130,8 +172,11 @@ pub enum ParticipationStatus {
 #[non_exhaustive]
 #[strum(ascii_case_insensitive, serialize_all = "lowercase")]
 pub enum ScheduleAgent {
+    /// The server sends scheduling messages.
     Server,
+    /// The client sends scheduling messages.
     Client,
+    /// No scheduling messages are sent.
     None,
 }
 
@@ -140,7 +185,9 @@ pub enum ScheduleAgent {
 #[non_exhaustive]
 #[strum(ascii_case_insensitive, serialize_all = "lowercase")]
 pub enum AlertRelativeTo {
+    /// Relative to the start of the calendar object.
     Start,
+    /// Relative to the end of the calendar object.
     End,
 }
 
@@ -149,7 +196,9 @@ pub enum AlertRelativeTo {
 #[non_exhaustive]
 #[strum(ascii_case_insensitive, serialize_all = "lowercase")]
 pub enum AlertAction {
+    /// Display an on-screen alert.
     Display,
+    /// Send an email notification.
     Email,
 }
 
@@ -164,7 +213,9 @@ pub struct Rgb {
 /// A color, which may be either a CSS3 color name or an RGB value.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Color {
+    /// A named CSS3 color.
     Css(Css3Color),
+    /// An `#RRGGBB` hex color.
     Rgb(Rgb),
 }
 


### PR DESCRIPTION
## Summary
- **json.rs**: Adds `///` doc comments to 12 public items — `TryFromJson`, `TryIntoJson`, `IntoJson`, `IntoDocumentError`, `LiftTypeError`, `HashSetTryFromJsonError`, `PathSegment` (+ 3 variant docs), `TypeErrorOr`, `TypeError`, `IntoIntError`, `IntoUnsignedIntError`, `DocumentError`
- **set.rs**: Adds variant-level `///` docs to all 14 enums (~45 variants total)
- **object.rs**: Adds `///` docs to 7 error types — `InvalidPatchObjectError`, `ObjectFromJsonError`, `InvalidUtcOffsetError`, `InvalidStatusCodeError`, `InvalidRequestStatusError`, `RRuleFromJsonError`, `ByRuleParseError`

## Test plan
- [x] `cargo doc --all-features --no-deps -p jscalendar` — builds cleanly
- [x] `cargo test --all-features` — all tests pass

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)