### PR TITLE
Add Cargo.toml metadata for crates.io publishing

### DIFF
--- a/calendar-types/Cargo.toml
+++ b/calendar-types/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2024"
 repository.workspace = true
 license.workspace = true
+description = "Date, time, and string primitive types for calendar data"
+keywords = ["calendar", "date", "time", "rfc3339"]
+categories = ["date-and-time"]
 
 [dependencies]
 dizzy.workspace = true

--- a/jscalendar/Cargo.toml
+++ b/jscalendar/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2024"
 repository.workspace = true
 license.workspace = true
+description = "JSCalendar (RFC 8984) data model with parser-agnostic JSON support"
+keywords = ["calendar", "jscalendar", "rfc8984", "json"]
+categories = ["date-and-time", "parser-implementations"]
 
 [features]
 serde_json = ["dep:serde_json"]

--- a/rfc5545-types/Cargo.toml
+++ b/rfc5545-types/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2024"
 repository.workspace = true
 license.workspace = true
+description = "iCalendar (RFC 5545) recurrence rule and component types"
+keywords = ["calendar", "icalendar", "rfc5545", "rrule"]
+categories = ["date-and-time"]
 
 [dependencies]
 calendar-types = { version = "0.1.0", path = "../calendar-types" }


### PR DESCRIPTION
## Summary
- Adds `description`, `keywords`, and `categories` to all three `Cargo.toml` files
- `calendar-types`: date/time primitives, keywords `calendar`/`date`/`time`/`rfc3339`
- `rfc5545-types`: iCalendar types, keywords `calendar`/`icalendar`/`rfc5545`/`rrule`
- `jscalendar`: JSCalendar data model, keywords `calendar`/`jscalendar`/`rfc8984`/`json`

## Test plan
- [x] `cargo publish --dry-run -p calendar-types` — succeeds
- [x] Downstream dry-runs fail only due to unpublished deps (expected pre-release)

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)