### PR TITLE
Fix documentation drift: add calico crate and fix page reference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ cargo test
 cargo test -p calendar-types
 cargo test -p rfc5545-types
 cargo test -p jscalendar
+cargo test -p calico
 
 # Run a specific test
 cargo test -p rfc5545-types behavior_with_table
@@ -25,11 +26,13 @@ cargo check
 
 ## Crate Structure
 
-This workspace contains three crates for working with calendar data formats:
+This workspace contains four crates for working with calendar data formats:
 
 - **calendar-types**: Foundation crate with date/time primitives (Year, Hour, Duration), string types (Uid, Uri), and common primitives (Sign). Based on RFC 3339.
 
 - **rfc5545-types**: iCalendar (RFC 5545) types. Contains recurrence rule (`RRule`) implementation with frequency-dependent BYxxx rules, and efficient bitset types for time components (SecondSet, MinuteSet, HourSet, MonthSet, MonthDaySet, WeekNoSet).
+
+- **calico**: iCalendar (RFC 5545) parser, printer, and data model. Uses winnow for parsing and the `structible` macro for builder-pattern construction.
 
 - **jscalendar**: JSCalendar (RFC 8984) implementation. Parser-agnostic design with optional serde support via feature flags.
 
@@ -40,8 +43,8 @@ This workspace contains three crates for working with calendar data formats:
 calendar-types
      ↓
 rfc5545-types
-     ↓
-jscalendar
+   ↓     ↓
+calico  jscalendar
 ```
 
 ### Key Design Patterns
@@ -50,7 +53,7 @@ jscalendar
 
 **Incremental parsing**: The parser in `jscalendar/src/parser.rs` uses `&mut &str` pattern for incremental parsing with explicit checkpointing for error recovery. Parsers must not modify input unless they succeed.
 
-**Structible macro**: JSCalendar object types (Event, Task, Group, Link) use the `structible` macro for builder-pattern construction with optional fields.
+**Structible macro**: JSCalendar object types (Event, Task, Group, Link) and calico component/parameter types use the `structible` macro for builder-pattern construction with optional fields.
 
 **Type markers**: DateTime uses marker types (Utc, Local, ()) to distinguish timezone context at compile time.
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Types specific to iCalendar (RFC 5545). These include
 - Recurrence rule types and representations (e.g. RRule, WeekdayNum, MonthDaySet).
 - String types used by RFC 5545 (e.g. ParamText).
 
+### `calico`
+
+An iCalendar (RFC 5545) parser, printer, and data model. Uses winnow for parsing.
+
 ### `jscalendar`
 
 A parser-agnostic implementation of JSCalendar (RFC 8984).

--- a/rfc5545-types/src/rrule.rs
+++ b/rfc5545-types/src/rrule.rs
@@ -952,7 +952,7 @@ pub enum ByRuleName {
     BySetPos,
 }
 
-/// The values in the table on page 43 of RFC 5545.
+/// The values in the table on page 44 of RFC 5545.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ByRuleBehavior {
     Limit,


### PR DESCRIPTION
## Summary
- CLAUDE.md and README.md documented only three of the four workspace crates — added the missing calico crate description, updated the dependency flow diagram, and expanded the structible macro note
- Fixed `ByRuleBehavior` doc comment in `rfc5545-types/src/rrule.rs` referencing RFC 5545 "page 43" when all other references in the codebase consistently say "page 44"

## Test plan
- [x] `cargo test --all-features` passes (all 15 test suites, 0 failures)
- [x] `cargo doc --no-deps` builds without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: doc-drift:/Users/oliver/projects/calendar-crates
task-type: doc-drift
task-title: Doc Drift Detector
provider: claude
score: 3.0
cost-tier: Medium (50-150k)
branch: main
iterations: 1
duration: 8m12s
run-started: 2026-02-22T02:00:03+01:00
nightshift:metadata -->
