### PR TITLE
calico: make WriteIcal generic over W: fmt::Write

### DIFF
--- a/calico/src/serializer/component.rs
+++ b/calico/src/serializer/component.rs
@@ -16,7 +16,7 @@ use crate::model::{
 // ============================================================================
 
 impl WriteIcal for Calendar {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         w.write_str("BEGIN:VCALENDAR\r\n")?;
         write_prop("VERSION", self.version(), w)?;
         write_prop("PRODID", self.prod_id(), w)?;
@@ -56,18 +56,9 @@ impl Calendar {
     }
 
     /// Writes this calendar in iCalendar format to the given writer with line folding.
-    pub fn write_ical_to(&self, w: &mut dyn fmt::Write) -> fmt::Result {
-        let mut fw = FoldingWriter::new(WriteAdapter(w));
+    pub fn write_ical_to<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
+        let mut fw = FoldingWriter::new(w);
         self.write_ical(&mut fw)
-    }
-}
-
-/// Adapter to allow `FoldingWriter<&mut dyn Write>` since we need ownership.
-struct WriteAdapter<'a>(&'a mut dyn fmt::Write);
-
-impl fmt::Write for WriteAdapter<'_> {
-    fn write_str(&mut self, s: &str) -> fmt::Result {
-        self.0.write_str(s)
     }
 }
 
@@ -76,7 +67,7 @@ impl fmt::Write for WriteAdapter<'_> {
 // ============================================================================
 
 impl WriteIcal for CalendarComponent {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         match self {
             CalendarComponent::Event(e) => e.write_ical(w),
             CalendarComponent::Todo(t) => t.write_ical(w),
@@ -93,7 +84,7 @@ impl WriteIcal for CalendarComponent {
 // ============================================================================
 
 impl WriteIcal for Event {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         w.write_str("BEGIN:VEVENT\r\n")?;
 
         write_opt_prop("DTSTAMP", self.dtstamp(), w)?;
@@ -160,7 +151,7 @@ impl WriteIcal for Event {
 // ============================================================================
 
 impl WriteIcal for Todo {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         w.write_str("BEGIN:VTODO\r\n")?;
 
         write_opt_prop("DTSTAMP", self.dtstamp(), w)?;
@@ -228,7 +219,7 @@ impl WriteIcal for Todo {
 // ============================================================================
 
 impl WriteIcal for Journal {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         w.write_str("BEGIN:VJOURNAL\r\n")?;
 
         write_prop("DTSTAMP", self.dtstamp(), w)?;
@@ -280,7 +271,7 @@ impl WriteIcal for Journal {
 // ============================================================================
 
 impl WriteIcal for FreeBusy {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         w.write_str("BEGIN:VFREEBUSY\r\n")?;
 
         write_prop("DTSTAMP", self.dtstamp(), w)?;
@@ -320,7 +311,7 @@ impl WriteIcal for FreeBusy {
 // ============================================================================
 
 impl WriteIcal for TimeZone {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         w.write_str("BEGIN:VTIMEZONE\r\n")?;
 
         write_prop("TZID", self.tz_id(), w)?;
@@ -344,7 +335,7 @@ impl WriteIcal for TimeZone {
 // ============================================================================
 
 impl WriteIcal for TzRule {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         let name = match self.kind() {
             &TzRuleKind::Standard => "STANDARD",
             &TzRuleKind::Daylight => "DAYLIGHT",
@@ -377,7 +368,7 @@ impl WriteIcal for TzRule {
 // ============================================================================
 
 impl WriteIcal for Alarm {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         match self {
             Alarm::Audio(a) => a.write_ical(w),
             Alarm::Display(a) => a.write_ical(w),
@@ -388,7 +379,7 @@ impl WriteIcal for Alarm {
 }
 
 impl WriteIcal for AudioAlarm {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         w.write_str("BEGIN:VALARM\r\n")?;
         write_action("AUDIO", w)?;
         write_trigger_prop(self.trigger(), w)?;
@@ -405,7 +396,7 @@ impl WriteIcal for AudioAlarm {
 }
 
 impl WriteIcal for DisplayAlarm {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         w.write_str("BEGIN:VALARM\r\n")?;
         write_action("DISPLAY", w)?;
         write_trigger_prop(self.trigger(), w)?;
@@ -420,7 +411,7 @@ impl WriteIcal for DisplayAlarm {
 }
 
 impl WriteIcal for EmailAlarm {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         w.write_str("BEGIN:VALARM\r\n")?;
         write_action("EMAIL", w)?;
         write_trigger_prop(self.trigger(), w)?;
@@ -438,7 +429,7 @@ impl WriteIcal for EmailAlarm {
 }
 
 impl WriteIcal for OtherAlarm {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         w.write_str("BEGIN:VALARM\r\n")?;
         write_prop("ACTION", self.action(), w)?;
         write_trigger_prop(self.trigger(), w)?;
@@ -460,7 +451,7 @@ impl WriteIcal for OtherAlarm {
 // ============================================================================
 
 impl WriteIcal for LocationComponent {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         w.write_str("BEGIN:VLOCATION\r\n")?;
         write_prop("UID", self.uid(), w)?;
         write_opt_prop("DESCRIPTION", self.description(), w)?;
@@ -475,7 +466,7 @@ impl WriteIcal for LocationComponent {
 }
 
 impl WriteIcal for ResourceComponent {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         w.write_str("BEGIN:VRESOURCE\r\n")?;
         write_prop("UID", self.uid(), w)?;
         write_opt_prop("DESCRIPTION", self.description(), w)?;
@@ -489,7 +480,7 @@ impl WriteIcal for ResourceComponent {
 }
 
 impl WriteIcal for Participant {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         w.write_str("BEGIN:PARTICIPANT\r\n")?;
         write_prop("UID", self.uid(), w)?;
         write_prop("PARTICIPANT-TYPE", self.participant_type(), w)?;
@@ -537,7 +528,7 @@ impl WriteIcal for Participant {
 // ============================================================================
 
 impl WriteIcal for OtherComponent {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         w.write_str("BEGIN:")?;
         w.write_str(&self.name)?;
         write_crlf(w)?;
@@ -554,16 +545,16 @@ impl WriteIcal for OtherComponent {
 // Helpers
 // ============================================================================
 
-fn write_action(action: &str, w: &mut dyn fmt::Write) -> fmt::Result {
+fn write_action<W: fmt::Write>(action: &str, w: &mut W) -> fmt::Result {
     w.write_str("ACTION:")?;
     w.write_str(action)?;
     write_crlf(w)
 }
 
-fn write_attach_vec(
+fn write_attach_vec<W: fmt::Write>(
     name: &str,
     props: Option<&Vec<crate::model::property::Prop<rfc5545_types::value::Attachment, Params>>>,
-    w: &mut dyn fmt::Write,
+    w: &mut W,
 ) -> fmt::Result {
     if let Some(ps) = props {
         for p in ps {
@@ -573,9 +564,9 @@ fn write_attach_vec(
     Ok(())
 }
 
-fn write_rdate_vec(
+fn write_rdate_vec<W: fmt::Write>(
     props: Option<&Vec<crate::model::property::Prop<rfc5545_types::time::RDateSeq, Params>>>,
-    w: &mut dyn fmt::Write,
+    w: &mut W,
 ) -> fmt::Result {
     if let Some(ps) = props {
         for p in ps {
@@ -585,9 +576,9 @@ fn write_rdate_vec(
     Ok(())
 }
 
-fn write_exdate_vec(
+fn write_exdate_vec<W: fmt::Write>(
     props: Option<&Vec<crate::model::property::Prop<rfc5545_types::time::DateTimeOrDate, Params>>>,
-    w: &mut dyn fmt::Write,
+    w: &mut W,
 ) -> fmt::Result {
     if let Some(ps) = props {
         for p in ps {
@@ -597,9 +588,9 @@ fn write_exdate_vec(
     Ok(())
 }
 
-fn write_styled_description_vec(
+fn write_styled_description_vec<W: fmt::Write>(
     props: Option<&Vec<crate::model::property::Prop<rfc5545_types::value::StyledDescriptionValue, Params>>>,
-    w: &mut dyn fmt::Write,
+    w: &mut W,
 ) -> fmt::Result {
     if let Some(ps) = props {
         for p in ps {

--- a/calico/src/serializer/mod.rs
+++ b/calico/src/serializer/mod.rs
@@ -18,7 +18,7 @@ use std::fmt;
 /// Writes a value in iCalendar text format.
 pub trait WriteIcal {
     /// Writes this value to the given writer in iCalendar wire format.
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result;
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result;
 
     /// Convenience method that serializes to a `String`.
     fn to_ical_string(&self) -> String {
@@ -83,7 +83,7 @@ impl<W: fmt::Write> fmt::Write for FoldingWriter<W> {
 /// Escapes a TEXT value for iCalendar content lines.
 ///
 /// Backslash-escapes semicolons, commas, backslashes, and newlines per RFC 5545 §3.3.11.
-pub fn escape_text(s: &str, w: &mut dyn fmt::Write) -> fmt::Result {
+pub fn escape_text<W: fmt::Write>(s: &str, w: &mut W) -> fmt::Result {
     for ch in s.chars() {
         match ch {
             '\\' => w.write_str("\\\\")?,
@@ -97,7 +97,7 @@ pub fn escape_text(s: &str, w: &mut dyn fmt::Write) -> fmt::Result {
 }
 
 /// Writes a CRLF line ending.
-pub fn write_crlf(w: &mut dyn fmt::Write) -> fmt::Result {
+pub fn write_crlf<W: fmt::Write>(w: &mut W) -> fmt::Result {
     w.write_str("\r\n")
 }
 

--- a/calico/src/serializer/parameter.rs
+++ b/calico/src/serializer/parameter.rs
@@ -11,14 +11,14 @@ use crate::model::{
 };
 
 /// Writes a parameter value that must be quoted (URI values per RFC 5545 §3.2).
-fn write_quoted_uri(uri: &Uri, w: &mut dyn fmt::Write) -> fmt::Result {
+fn write_quoted_uri<W: fmt::Write>(uri: &Uri, w: &mut W) -> fmt::Result {
     w.write_char('"')?;
     w.write_str(uri.as_str())?;
     w.write_char('"')
 }
 
 /// Writes a list of quoted URIs, comma-separated.
-fn write_quoted_uri_list(uris: &Vec1<Box<Uri>>, w: &mut dyn fmt::Write) -> fmt::Result {
+fn write_quoted_uri_list<W: fmt::Write>(uris: &Vec1<Box<Uri>>, w: &mut W) -> fmt::Result {
     for (i, uri) in uris.iter().enumerate() {
         if i > 0 {
             w.write_char(',')?;
@@ -30,13 +30,13 @@ fn write_quoted_uri_list(uris: &Vec1<Box<Uri>>, w: &mut dyn fmt::Write) -> fmt::
 
 /// Writes a `ParamValue`, quoting it if it contains characters that require quoting
 /// (colons, semicolons, commas, or spaces).
-fn write_param_value(pv: &ParamValue, w: &mut dyn fmt::Write) -> fmt::Result {
+fn write_param_value<W: fmt::Write>(pv: &ParamValue, w: &mut W) -> fmt::Result {
     let s = pv.as_str();
     write_maybe_quoted(s, w)
 }
 
 /// Writes a string, quoting it if it contains `:`, `;`, `,`, or space.
-fn write_maybe_quoted(s: &str, w: &mut dyn fmt::Write) -> fmt::Result {
+fn write_maybe_quoted<W: fmt::Write>(s: &str, w: &mut W) -> fmt::Result {
     let needs_quoting = s.contains(':') || s.contains(';') || s.contains(',') || s.contains(' ');
     if needs_quoting {
         w.write_char('"')?;
@@ -52,7 +52,7 @@ fn write_maybe_quoted(s: &str, w: &mut dyn fmt::Write) -> fmt::Result {
 /// This is a macro because both types have the same field names but are different types.
 macro_rules! write_shared_params {
     ($self:expr, $w:expr) => {{
-        let w: &mut dyn fmt::Write = $w;
+        let w = $w;
         if let Some(uri) = $self.alternate_representation() {
             w.write_str(";ALTREP=")?;
             write_quoted_uri(uri, w)?;
@@ -167,7 +167,7 @@ macro_rules! write_shared_params {
 }
 
 impl WriteIcal for Params {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         if let Some(ft) = self.format_type() {
             w.write_str(";FMTTYPE=")?;
             w.write_str(ft.as_str())?;
@@ -181,7 +181,7 @@ impl WriteIcal for Params {
 }
 
 impl WriteIcal for StructuredDataParams {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         // Required params
         w.write_str(";FMTTYPE=")?;
         w.write_str(self.format_type().as_str())?;

--- a/calico/src/serializer/primitive.rs
+++ b/calico/src/serializer/primitive.rs
@@ -31,13 +31,13 @@ use crate::model::{
 // ============================================================================
 
 impl WriteIcal for Date {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         write!(w, "{:04}{:02}{:02}", self.year().get(), self.month() as u8, self.day() as u8)
     }
 }
 
 impl WriteIcal for Time {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         write!(
             w,
             "{:02}{:02}{:02}",
@@ -57,7 +57,7 @@ impl WriteIcal for Time {
 }
 
 impl WriteIcal for DateTime<Utc> {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         self.date.write_ical(w)?;
         w.write_char('T')?;
         self.time.write_ical(w)?;
@@ -66,7 +66,7 @@ impl WriteIcal for DateTime<Utc> {
 }
 
 impl WriteIcal for DateTime<Local> {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         self.date.write_ical(w)?;
         w.write_char('T')?;
         self.time.write_ical(w)
@@ -74,7 +74,7 @@ impl WriteIcal for DateTime<Local> {
 }
 
 impl WriteIcal for DateTime<TimeFormat> {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         self.date.write_ical(w)?;
         w.write_char('T')?;
         self.time.write_ical(w)?;
@@ -90,7 +90,7 @@ impl WriteIcal for DateTime<TimeFormat> {
 // ============================================================================
 
 impl WriteIcal for UtcOffset {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         write!(
             w,
             "{}{:02}{:02}",
@@ -111,7 +111,7 @@ impl WriteIcal for UtcOffset {
 // ============================================================================
 
 impl WriteIcal for DateTimeOrDate<Utc> {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         match self {
             DateTimeOrDate::DateTime(dt) => dt.write_ical(w),
             DateTimeOrDate::Date(d) => d.write_ical(w),
@@ -120,7 +120,7 @@ impl WriteIcal for DateTimeOrDate<Utc> {
 }
 
 impl WriteIcal for DateTimeOrDate<TimeFormat> {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         match self {
             DateTimeOrDate::DateTime(dt) => dt.write_ical(w),
             DateTimeOrDate::Date(d) => d.write_ical(w),
@@ -133,7 +133,7 @@ impl WriteIcal for DateTimeOrDate<TimeFormat> {
 // ============================================================================
 
 impl WriteIcal for Period<TimeFormat> {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         match self {
             Period::Explicit { start, end } => {
                 start.write_ical(w)?;
@@ -154,13 +154,13 @@ impl WriteIcal for Period<TimeFormat> {
 // ============================================================================
 
 impl WriteIcal for Duration {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         write!(w, "{self}")
     }
 }
 
 impl WriteIcal for SignedDuration {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         write!(w, "{self}")
     }
 }
@@ -170,7 +170,7 @@ impl WriteIcal for SignedDuration {
 // ============================================================================
 
 impl WriteIcal for Geo {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         write!(w, "{};{}", self.lat, self.lon)
     }
 }
@@ -180,7 +180,7 @@ impl WriteIcal for Geo {
 // ============================================================================
 
 impl WriteIcal for RDateSeq {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         match self {
             RDateSeq::DateTime(dts) => write_comma_separated(dts, w),
             RDateSeq::Date(ds) => write_comma_separated(ds, w),
@@ -190,7 +190,7 @@ impl WriteIcal for RDateSeq {
 }
 
 impl WriteIcal for ExDateSeq {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         match self {
             ExDateSeq::DateTime(dts) => write_comma_separated(dts, w),
             ExDateSeq::Date(ds) => write_comma_separated(ds, w),
@@ -203,7 +203,7 @@ impl WriteIcal for ExDateSeq {
 // ============================================================================
 
 impl WriteIcal for TriggerValue {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         match self {
             TriggerValue::Duration(d) => d.write_ical(w),
             TriggerValue::DateTime(dt) => dt.write_ical(w),
@@ -216,7 +216,7 @@ impl WriteIcal for TriggerValue {
 // ============================================================================
 
 impl WriteIcal for RequestStatus {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         // RequestStatus Display writes: code;description[;exception_data]
         // but description/exception_data TEXT values need escaping
         write!(w, "{}", self.code)?;
@@ -235,7 +235,7 @@ impl WriteIcal for RequestStatus {
 // ============================================================================
 
 impl WriteIcal for Attachment {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         match self {
             Attachment::Uri(uri) => w.write_str(uri.as_str()),
             Attachment::Binary(data) => {
@@ -251,7 +251,7 @@ impl WriteIcal for Attachment {
 // ============================================================================
 
 impl WriteIcal for StyledDescriptionValue {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         match self {
             StyledDescriptionValue::Text(s) => super::escape_text(s, w),
             StyledDescriptionValue::Uri(uri) => w.write_str(uri.as_str()),
@@ -265,7 +265,7 @@ impl WriteIcal for StyledDescriptionValue {
 // ============================================================================
 
 impl<S: AsRef<str>> WriteIcal for Value<S> {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         match self {
             Value::Binary(data) => {
                 let encoded = BASE64.encode(data);
@@ -304,7 +304,7 @@ macro_rules! impl_write_ical_via_display {
     ($($ty:ty),+ $(,)?) => {
         $(
             impl WriteIcal for $ty {
-                fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+                fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
                     write!(w, "{self}")
                 }
             }
@@ -344,7 +344,7 @@ impl_write_ical_via_display!(
 // ============================================================================
 
 impl<T: WriteIcal, S: fmt::Display> WriteIcal for calendar_types::set::Token<T, S> {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         match self {
             calendar_types::set::Token::Known(t) => t.write_ical(w),
             calendar_types::set::Token::Unknown(s) => write!(w, "{s}"),
@@ -357,7 +357,7 @@ impl<T: WriteIcal, S: fmt::Display> WriteIcal for calendar_types::set::Token<T, 
 // ============================================================================
 
 impl WriteIcal for Version {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         match self {
             Version::V2_0 => w.write_str("2.0"),
         }
@@ -365,74 +365,74 @@ impl WriteIcal for Version {
 }
 
 impl WriteIcal for rfc5545_types::set::Gregorian {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         w.write_str("GREGORIAN")
     }
 }
 
 impl WriteIcal for ThisAndFuture {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         w.write_str("THISANDFUTURE")
     }
 }
 
 impl WriteIcal for Priority {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         let n = *self as u8;
         write!(w, "{n}")
     }
 }
 
 impl WriteIcal for Percent {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         write!(w, "{}", self.get())
     }
 }
 
 impl WriteIcal for bool {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         w.write_str(if *self { "TRUE" } else { "FALSE" })
     }
 }
 
 impl WriteIcal for i32 {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         write!(w, "{self}")
     }
 }
 
 impl WriteIcal for f64 {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         write!(w, "{self}")
     }
 }
 
 impl WriteIcal for str {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         super::escape_text(self, w)
     }
 }
 
 impl WriteIcal for String {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         super::escape_text(self, w)
     }
 }
 
 impl WriteIcal for Box<Uri> {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         w.write_str(self.as_str())
     }
 }
 
 impl WriteIcal for Box<Uid> {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         w.write_str(self.as_str())
     }
 }
 
 impl WriteIcal for Box<TzId> {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         w.write_str(self.as_str())
     }
 }
@@ -442,7 +442,7 @@ impl WriteIcal for Box<TzId> {
 // ============================================================================
 
 impl WriteIcal for Vec<String> {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         for (i, s) in self.iter().enumerate() {
             if i > 0 {
                 w.write_char(',')?;
@@ -458,7 +458,7 @@ impl WriteIcal for Vec<String> {
 // ============================================================================
 
 impl WriteIcal for Vec<Period> {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         write_comma_separated(self, w)
     }
 }
@@ -468,7 +468,7 @@ impl WriteIcal for Vec<Period> {
 // ============================================================================
 
 impl WriteIcal for RRule {
-    fn write_ical(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_ical<W: fmt::Write>(&self, w: &mut W) -> fmt::Result {
         let freq = Freq::from(&self.freq);
         write!(w, "FREQ={}", freq_str(freq))?;
 
@@ -528,7 +528,7 @@ fn freq_str(freq: Freq) -> &'static str {
     }
 }
 
-fn write_weekday(wd: calendar_types::time::Weekday, w: &mut dyn fmt::Write) -> fmt::Result {
+fn write_weekday<W: fmt::Write>(wd: calendar_types::time::Weekday, w: &mut W) -> fmt::Result {
     w.write_str(match wd {
         calendar_types::time::Weekday::Monday => "MO",
         calendar_types::time::Weekday::Tuesday => "TU",
@@ -540,7 +540,7 @@ fn write_weekday(wd: calendar_types::time::Weekday, w: &mut dyn fmt::Write) -> f
     })
 }
 
-fn write_weekday_num(wn: &WeekdayNum, w: &mut dyn fmt::Write) -> fmt::Result {
+fn write_weekday_num<W: fmt::Write>(wn: &WeekdayNum, w: &mut W) -> fmt::Result {
     if let Some((sign, week)) = wn.ordinal {
         match sign {
             Sign::Pos => {}
@@ -551,7 +551,7 @@ fn write_weekday_num(wn: &WeekdayNum, w: &mut dyn fmt::Write) -> fmt::Result {
     write_weekday(wn.weekday, w)
 }
 
-fn write_core_by_rules(rules: &CoreByRules, w: &mut dyn fmt::Write) -> fmt::Result {
+fn write_core_by_rules<W: fmt::Write>(rules: &CoreByRules, w: &mut W) -> fmt::Result {
     if let Some(set) = &rules.by_second {
         w.write_str(";BYSECOND=")?;
         write_second_set(set, w)?;
@@ -593,7 +593,7 @@ fn write_core_by_rules(rules: &CoreByRules, w: &mut dyn fmt::Write) -> fmt::Resu
     Ok(())
 }
 
-fn write_by_period_day_rules(rules: &ByPeriodDayRules, w: &mut dyn fmt::Write) -> fmt::Result {
+fn write_by_period_day_rules<W: fmt::Write>(rules: &ByPeriodDayRules, w: &mut W) -> fmt::Result {
     if let Some(set) = &rules.by_month_day {
         w.write_str(";BYMONTHDAY=")?;
         write_month_day_set(set, w)?;
@@ -612,7 +612,7 @@ fn write_by_period_day_rules(rules: &ByPeriodDayRules, w: &mut dyn fmt::Write) -
     Ok(())
 }
 
-fn write_by_month_day_rule(rules: &ByMonthDayRule, w: &mut dyn fmt::Write) -> fmt::Result {
+fn write_by_month_day_rule<W: fmt::Write>(rules: &ByMonthDayRule, w: &mut W) -> fmt::Result {
     if let Some(set) = &rules.by_month_day {
         w.write_str(";BYMONTHDAY=")?;
         write_month_day_set(set, w)?;
@@ -620,7 +620,7 @@ fn write_by_month_day_rule(rules: &ByMonthDayRule, w: &mut dyn fmt::Write) -> fm
     Ok(())
 }
 
-fn write_yearly_by_rules(rules: &YearlyByRules, w: &mut dyn fmt::Write) -> fmt::Result {
+fn write_yearly_by_rules<W: fmt::Write>(rules: &YearlyByRules, w: &mut W) -> fmt::Result {
     if let Some(set) = &rules.by_month_day {
         w.write_str(";BYMONTHDAY=")?;
         write_month_day_set(set, w)?;
@@ -643,7 +643,7 @@ fn write_yearly_by_rules(rules: &YearlyByRules, w: &mut dyn fmt::Write) -> fmt::
     Ok(())
 }
 
-fn write_second_set(set: &SecondSet, w: &mut dyn fmt::Write) -> fmt::Result {
+fn write_second_set<W: fmt::Write>(set: &SecondSet, w: &mut W) -> fmt::Result {
     let mut first = true;
     for s in rfc5545_types::rrule::Second::iter() {
         if set.get(s) {
@@ -657,7 +657,7 @@ fn write_second_set(set: &SecondSet, w: &mut dyn fmt::Write) -> fmt::Result {
     Ok(())
 }
 
-fn write_minute_set(set: &MinuteSet, w: &mut dyn fmt::Write) -> fmt::Result {
+fn write_minute_set<W: fmt::Write>(set: &MinuteSet, w: &mut W) -> fmt::Result {
     let mut first = true;
     for m in rfc5545_types::rrule::Minute::iter() {
         if set.get(m) {
@@ -671,7 +671,7 @@ fn write_minute_set(set: &MinuteSet, w: &mut dyn fmt::Write) -> fmt::Result {
     Ok(())
 }
 
-fn write_hour_set(set: &HourSet, w: &mut dyn fmt::Write) -> fmt::Result {
+fn write_hour_set<W: fmt::Write>(set: &HourSet, w: &mut W) -> fmt::Result {
     let mut first = true;
     for h in rfc5545_types::rrule::Hour::iter() {
         if set.get(h) {
@@ -685,7 +685,7 @@ fn write_hour_set(set: &HourSet, w: &mut dyn fmt::Write) -> fmt::Result {
     Ok(())
 }
 
-fn write_month_set(set: &MonthSet, w: &mut dyn fmt::Write) -> fmt::Result {
+fn write_month_set<W: fmt::Write>(set: &MonthSet, w: &mut W) -> fmt::Result {
     let mut first = true;
     for m in calendar_types::time::Month::iter() {
         if set.get(m) {
@@ -699,7 +699,7 @@ fn write_month_set(set: &MonthSet, w: &mut dyn fmt::Write) -> fmt::Result {
     Ok(())
 }
 
-fn write_month_day_set(set: &MonthDaySet, w: &mut dyn fmt::Write) -> fmt::Result {
+fn write_month_day_set<W: fmt::Write>(set: &MonthDaySet, w: &mut W) -> fmt::Result {
     let mut first = true;
     // Positive days 1..=31
     for d in 1..=31u8 {
@@ -730,7 +730,7 @@ fn write_month_day_set(set: &MonthDaySet, w: &mut dyn fmt::Write) -> fmt::Result
     Ok(())
 }
 
-fn write_week_no_set(set: &WeekNoSet, w: &mut dyn fmt::Write) -> fmt::Result {
+fn write_week_no_set<W: fmt::Write>(set: &WeekNoSet, w: &mut W) -> fmt::Result {
     let mut first = true;
     // Positive weeks 1..=53
     for i in 1..=53u8 {
@@ -765,7 +765,7 @@ fn write_week_no_set(set: &WeekNoSet, w: &mut dyn fmt::Write) -> fmt::Result {
 // Helpers
 // ============================================================================
 
-fn write_comma_separated<T: WriteIcal>(items: &[T], w: &mut dyn fmt::Write) -> fmt::Result {
+fn write_comma_separated<T: WriteIcal, W: fmt::Write>(items: &[T], w: &mut W) -> fmt::Result {
     for (i, item) in items.iter().enumerate() {
         if i > 0 {
             w.write_char(',')?;

--- a/calico/src/serializer/property.rs
+++ b/calico/src/serializer/property.rs
@@ -11,11 +11,11 @@ use crate::model::{
 };
 
 /// Writes a content line: `NAME` + params + `:` + value + CRLF.
-pub fn write_content_line(
+pub fn write_content_line<P: WriteIcal, V: WriteIcal, W: fmt::Write>(
     name: &str,
-    params: &dyn WriteIcal,
-    value: &dyn WriteIcal,
-    w: &mut dyn fmt::Write,
+    params: &P,
+    value: &V,
+    w: &mut W,
 ) -> fmt::Result {
     w.write_str(name)?;
     params.write_ical(w)?;
@@ -25,19 +25,19 @@ pub fn write_content_line(
 }
 
 /// Writes a single `Prop<V, P>` as a content line.
-pub fn write_prop<V: WriteIcal, P: WriteIcal>(
+pub fn write_prop<V: WriteIcal, P: WriteIcal, W: fmt::Write>(
     name: &str,
     prop: &Prop<V, P>,
-    w: &mut dyn fmt::Write,
+    w: &mut W,
 ) -> fmt::Result {
     write_content_line(name, &prop.params, &prop.value, w)
 }
 
 /// Writes an optional prop if present. Accepts `Option<&Prop>` (structible getter style).
-pub fn write_opt_prop<V: WriteIcal, P: WriteIcal>(
+pub fn write_opt_prop<V: WriteIcal, P: WriteIcal, W: fmt::Write>(
     name: &str,
     prop: Option<&Prop<V, P>>,
-    w: &mut dyn fmt::Write,
+    w: &mut W,
 ) -> fmt::Result {
     if let Some(p) = prop {
         write_prop(name, p, w)?;
@@ -46,10 +46,10 @@ pub fn write_opt_prop<V: WriteIcal, P: WriteIcal>(
 }
 
 /// Writes a vec of props if present. Accepts `Option<&Vec<Prop>>` (structible getter style).
-pub fn write_vec_prop<V: WriteIcal, P: WriteIcal>(
+pub fn write_vec_prop<V: WriteIcal, P: WriteIcal, W: fmt::Write>(
     name: &str,
     props: Option<&Vec<Prop<V, P>>>,
-    w: &mut dyn fmt::Write,
+    w: &mut W,
 ) -> fmt::Result {
     if let Some(ps) = props {
         for p in ps {
@@ -60,9 +60,9 @@ pub fn write_vec_prop<V: WriteIcal, P: WriteIcal>(
 }
 
 /// Writes a `StructuredDataProp`.
-pub fn write_structured_data_prop(
+pub fn write_structured_data_prop<W: fmt::Write>(
     prop: &StructuredDataProp,
-    w: &mut dyn fmt::Write,
+    w: &mut W,
 ) -> fmt::Result {
     match prop {
         StructuredDataProp::Binary(p) => {
@@ -91,9 +91,9 @@ pub fn write_structured_data_prop(
 }
 
 /// Writes a vec of `StructuredDataProp`s.
-pub fn write_structured_data_props(
+pub fn write_structured_data_props<W: fmt::Write>(
     props: Option<&Vec<StructuredDataProp>>,
-    w: &mut dyn fmt::Write,
+    w: &mut W,
 ) -> fmt::Result {
     if let Some(ps) = props {
         for p in ps {
@@ -104,9 +104,9 @@ pub fn write_structured_data_props(
 }
 
 /// Writes x-properties by iterating the structible catch-all.
-pub fn write_x_property_iter<'a>(
+pub fn write_x_property_iter<'a, W: fmt::Write>(
     iter: impl Iterator<Item = (&'a Box<CaselessStr>, &'a Vec<Prop<Value<String>, Params>>)>,
-    w: &mut dyn fmt::Write,
+    w: &mut W,
 ) -> fmt::Result {
     for (name, props) in iter {
         for prop in props {
@@ -121,10 +121,10 @@ pub fn write_x_property_iter<'a>(
 }
 
 /// Writes a DateTimeOrDate property with correct VALUE parameter.
-pub fn write_dtod_prop(
+pub fn write_dtod_prop<W: fmt::Write>(
     name: &str,
     prop: &Prop<rfc5545_types::time::DateTimeOrDate, Params>,
-    w: &mut dyn fmt::Write,
+    w: &mut W,
 ) -> fmt::Result {
     w.write_str(name)?;
     if prop.value.is_date() {
@@ -137,10 +137,10 @@ pub fn write_dtod_prop(
 }
 
 /// Writes an optional DateTimeOrDate property.
-pub fn write_opt_dtod_prop(
+pub fn write_opt_dtod_prop<W: fmt::Write>(
     name: &str,
     prop: Option<&Prop<rfc5545_types::time::DateTimeOrDate, Params>>,
-    w: &mut dyn fmt::Write,
+    w: &mut W,
 ) -> fmt::Result {
     if let Some(p) = prop {
         write_dtod_prop(name, p, w)?;
@@ -149,10 +149,10 @@ pub fn write_opt_dtod_prop(
 }
 
 /// Writes RDATE properties with correct VALUE parameter for date-only sequences.
-pub fn write_rdate_seq_prop(
+pub fn write_rdate_seq_prop<W: fmt::Write>(
     name: &str,
     prop: &Prop<rfc5545_types::time::RDateSeq, Params>,
-    w: &mut dyn fmt::Write,
+    w: &mut W,
 ) -> fmt::Result {
     w.write_str(name)?;
     match &prop.value {
@@ -167,9 +167,9 @@ pub fn write_rdate_seq_prop(
 }
 
 /// Writes EXDATE property with correct VALUE parameter.
-pub fn write_exdate_prop(
+pub fn write_exdate_prop<W: fmt::Write>(
     prop: &Prop<rfc5545_types::time::DateTimeOrDate, Params>,
-    w: &mut dyn fmt::Write,
+    w: &mut W,
 ) -> fmt::Result {
     w.write_str("EXDATE")?;
     if prop.value.is_date() {
@@ -182,10 +182,10 @@ pub fn write_exdate_prop(
 }
 
 /// Writes an Attachment property with correct VALUE/ENCODING params.
-pub fn write_attach_prop(
+pub fn write_attach_prop<W: fmt::Write>(
     name: &str,
     prop: &Prop<rfc5545_types::value::Attachment, Params>,
-    w: &mut dyn fmt::Write,
+    w: &mut W,
 ) -> fmt::Result {
     w.write_str(name)?;
     match &prop.value {
@@ -201,9 +201,9 @@ pub fn write_attach_prop(
 }
 
 /// Writes a StyledDescriptionValue property with correct VALUE param.
-pub fn write_styled_description_prop(
+pub fn write_styled_description_prop<W: fmt::Write>(
     prop: &Prop<rfc5545_types::value::StyledDescriptionValue, Params>,
-    w: &mut dyn fmt::Write,
+    w: &mut W,
 ) -> fmt::Result {
     w.write_str("STYLED-DESCRIPTION")?;
     match &prop.value {
@@ -225,9 +225,9 @@ pub fn write_styled_description_prop(
 }
 
 /// Writes a TriggerValue property with correct VALUE param.
-pub fn write_trigger_prop(
+pub fn write_trigger_prop<W: fmt::Write>(
     prop: &Prop<rfc5545_types::time::TriggerValue, Params>,
-    w: &mut dyn fmt::Write,
+    w: &mut W,
 ) -> fmt::Result {
     w.write_str("TRIGGER")?;
     match &prop.value {


### PR DESCRIPTION
## Summary

- Replace `&mut dyn fmt::Write` with a generic `W: fmt::Write` type parameter on `WriteIcal::write_ical` and all serializer helper functions
- Make `write_content_line` generic over its params/value arguments (previously `&dyn WriteIcal` trait objects)
- Make `Calendar::write_ical_to` generic, removing the `WriteAdapter` wrapper (since `FoldingWriter<&mut W>` works directly via `&mut W: fmt::Write`)
- Remove the `let w: &mut dyn fmt::Write = $w` cast in the `write_shared_params!` macro

## Test plan

- [x] `cargo test --all-features` — all tests pass
- [x] `cargo doc --all-features --no-deps` — builds cleanly (pre-existing unrelated warning only)
- [x] Round-trip serialization tests in `calico/tests/round_trip.rs` exercise the full path and pass without modification

🤖 Generated with [Claude Code](https://claude.com/claude-code)